### PR TITLE
メッセージをキューで管理できるようにする

### DIFF
--- a/Onigokko/MessageManager.hpp
+++ b/Onigokko/MessageManager.hpp
@@ -1,7 +1,7 @@
 ﻿#pragma once
 #include <unordered_map>
 #include <string>
-#include <vector>
+#include <queue>
 #include <memory>
 
 namespace game {
@@ -56,11 +56,24 @@ namespace game {
 		void sendAll();
 
 		/**
+		 * @brief 先頭のメッセージを送信する。
+		 * 
+		 */
+		void send();
+
+		/**
+		 * @brief 未送信のメッセージが空かどうかを判定する。
+		 * 
+		 * @return メッセージが空ならtrue
+		 */
+		bool isEmpty() const { return _messages.empty(); }
+
+		/**
 		 * 受け取ったがまだ送信していないメッセージの参照を取得する。
 		 * 
 		 * @return  受け取ったがまだ送信していないメッセージ
 		 */
-		const std::vector<std::string>& getMessages() const { return _messages; }
+		const std::queue<std::string>& getMessages() const { return _messages; }
 
 		/**
 		 * メッセージ送受信者の階層構造の参照を取得する。
@@ -82,7 +95,7 @@ namespace game {
 		
 		int useNextId(const std::string& tag);
 	private:
-		std::vector<std::string> _messages;
+		std::queue<std::string> _messages;
 		/*
 		受信者の階層構造
 		tag -> id

--- a/UnitTest/MessageManagerTest.cpp
+++ b/UnitTest/MessageManagerTest.cpp
@@ -203,5 +203,40 @@ namespace game {
 			enemy->raiseHand("enemy");
 			mm->sendAll();
 		}
+
+		TEST_METHOD(SendMessage) {
+			MessageManagerPtr mm(new MessageManager());
+			std::shared_ptr<Enemy> enemy(new Enemy(mm));
+			enemy->raiseHand("enemy");
+
+			mm->receive("[enemy][0]run(34.5)");
+			mm->send();
+			Assert::AreEqual(static_cast<size_t>(1), enemy->getReceivedMessages().size());
+			Assert::AreEqual(std::string("run(34.5)"), enemy->getReceivedMessages()[0]);
+		}
+
+		TEST_METHOD(SendMultipleMessage) {
+			MessageManagerPtr mm(new MessageManager());
+			std::shared_ptr<Enemy> enemy(new Enemy(mm));
+			enemy->raiseHand("enemy");
+
+			mm->receive("[enemy][0]run(34.5)");
+			mm->receive("[enemy][0]jump()");
+			mm->send();
+			Assert::AreEqual(static_cast<size_t>(1), enemy->getReceivedMessages().size());
+			Assert::AreEqual(std::string("run(34.5)"), enemy->getReceivedMessages()[0]);
+			mm->send();
+			Assert::AreEqual(static_cast<size_t>(2), enemy->getReceivedMessages().size());
+			Assert::AreEqual(std::string("jump()"), enemy->getReceivedMessages()[1]);
+		}
+
+		TEST_METHOD(Send0Message) {
+			MessageManagerPtr mm(new MessageManager());
+			std::shared_ptr<Enemy> enemy(new Enemy(mm));
+			enemy->raiseHand("enemy");
+
+			mm->send();
+			Assert::AreEqual(static_cast<size_t>(0), enemy->getReceivedMessages().size());
+		}
 	};
 }

--- a/UnitTest/MessageManagerTest.cpp
+++ b/UnitTest/MessageManagerTest.cpp
@@ -117,7 +117,7 @@ namespace game {
 			mm->receive("");
 		}
 
-		TEST_METHOD(SendMultipleMessages) {
+		TEST_METHOD(SendAllMultipleMessages) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			const std::string msg1 = "die()";
@@ -132,7 +132,7 @@ namespace game {
 			Assert::AreEqual(msg2, enemy->getReceivedMessage(1));
 		}
 		
-		TEST_METHOD(SendInvalidMessages) {
+		TEST_METHOD(SendAllInvalidMessages) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			enemy->raiseHand("enemy");
@@ -150,7 +150,7 @@ namespace game {
 			Assert::Fail();
 		}
 		
-		TEST_METHOD(SendMessagesBroadcast) {
+		TEST_METHOD(SendAllMessagesBroadcast) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			const std::string msg = "run(34.5)";
@@ -167,7 +167,7 @@ namespace game {
 			Assert::AreEqual(msg, enemy->getReceivedMessage(1));
 		}
 		
-		TEST_METHOD(SendMessageToNotExistTag) {
+		TEST_METHOD(SendAllMessageToNotExistTag) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			enemy->raiseHand("enemy");
@@ -177,7 +177,7 @@ namespace game {
 			Assert::IsTrue(enemy->getReceivedMessages().empty());
 		}
 		
-		TEST_METHOD(SendMessageToNotExistTagBroadcast) {
+		TEST_METHOD(SendAllMessageToNotExistTagBroadcast) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			enemy->raiseHand("enemy");
@@ -187,7 +187,7 @@ namespace game {
 			Assert::IsTrue(enemy->getReceivedMessages().empty());
 		}
 		
-		TEST_METHOD(SendMessageToNotExistCommunicator) {
+		TEST_METHOD(SendAllMessageToNotExistCommunicator) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			enemy->raiseHand("enemy");
@@ -197,7 +197,7 @@ namespace game {
 			Assert::IsTrue(enemy->getReceivedMessages().empty());
 		}
 		
-		TEST_METHOD(Send0Messages) {
+		TEST_METHOD(SendAll0Messages) {
 			MessageManagerPtr mm(new MessageManager());
 			std::shared_ptr<Enemy> enemy(new Enemy(mm));
 			enemy->raiseHand("enemy");


### PR DESCRIPTION
# 変更
- `std::queue`でメッセージをキューで管理するようにした
- メッセージを一つ送信するのをO(1)で行えるようになった
# 関連イシュー
close #51 